### PR TITLE
Task: Connection DB string changed to env file in checkTables.js

### DIFF
--- a/backend/checkTables.js
+++ b/backend/checkTables.js
@@ -1,9 +1,12 @@
 import pkg from 'pg';
+import pool from "./db/db.js";
 const { Pool } = pkg;
 
-const pool = new Pool({
-    connectionString: 'postgresql://postgres:wluoFmQftmYQqWnfkORBGRZNcIYveFzR@gondola.proxy.rlwy.net:46655/railway'
-});
+// require('dotenv').config();
+
+// const pool = new Pool({
+//     connectionString: process.env.DATABASE_URL
+// });
 
 async function checkTables() {
     try {


### PR DESCRIPTION
This PR moves the hardcoded PostgreSQL connection String from checkTables.js to use the pool imported from db/db.js.

It imports the the pool from db/db.js and use it instead of creating a new pool.